### PR TITLE
Removing 4.8 from dependency name

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -14,7 +14,7 @@ distribution are installed, for Debian and Ubuntu these are:
 
     apt-get install qt4-qmake libqt4-dev build-essential libboost-dev libboost-system-dev \
         libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev \
-        libssl-dev libdb4.8++-dev
+        libssl-dev libdb++-dev
 
 then execute the following:
 


### PR DESCRIPTION
the 4.8 is not needed, and causes an error when trying to install the
package on ubuntu
